### PR TITLE
Refactor score system

### DIFF
--- a/src/main/kotlin/xyz/devcmb/tumblers/Constants.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/Constants.kt
@@ -2,6 +2,6 @@ package xyz.devcmb.tumblers
 
 data object Constants {
     val IS_DEVELOPMENT = true
-    const val VERSION: String = "021"
-    const val BRANCH: String = "game/crumble"
+    const val VERSION: String = "01f"
+    const val BRANCH: String = "feat/teamscorechanges"
 }

--- a/src/main/kotlin/xyz/devcmb/tumblers/controllers/EventController.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/controllers/EventController.kt
@@ -106,7 +106,10 @@ class EventController : IController {
 
     fun grantTeamScore(team: Team, amount: Int) {
         if(!eventMode) return
-        teamScores.put(team, (teamScores[team] ?: 0) + amount)
+
+        team.getOnlinePlayers().forEach {
+            grantScore(it, amount / 4)
+        }
     }
 
     fun getEventTeamPlacements(): ArrayList<Pair<Team, Int>> {

--- a/src/main/kotlin/xyz/devcmb/tumblers/controllers/EventController.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/controllers/EventController.kt
@@ -104,14 +104,6 @@ class EventController : IController {
         teamScores.put(tumblingPlayer.team, (teamScores[tumblingPlayer.team] ?: 0) + amount)
     }
 
-    fun grantTeamScore(team: Team, amount: Int) {
-        if(!eventMode) return
-
-        team.getOnlinePlayers().forEach {
-            grantScore(it, amount / 4)
-        }
-    }
-
     fun getEventTeamPlacements(): ArrayList<Pair<Team, Int>> {
         val sorted = teamScores.entries.sortedWith(
             compareByDescending<MutableMap.MutableEntry<Team, Int>> { it.value }

--- a/src/main/kotlin/xyz/devcmb/tumblers/controllers/games/crumble/CrumbleController.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/controllers/games/crumble/CrumbleController.kt
@@ -144,14 +144,9 @@ class CrumbleController : GameBase(
     flags = setOf(),
     scores = hashMapOf(
         CommonScoreSource.KILL to 45,
-        CommonScoreSource.INDIV_ROUND_WIN to 120,
-        CommonScoreSource.INDIV_ROUND_DRAW to 50,
-        CommonScoreSource.INDIV_ROUND_LOSE to 25,
-        CommonScoreSource.TEAM_ROUND_WIN to 250,
-        CommonScoreSource.TEAM_ROUND_DRAW to 140,
-        CommonScoreSource.TEAM_ROUND_LOSE to 50,
-        CommonScoreSource.TEAM_PLACEMENT to 80,
-        CommonScoreSource.INDIVIDUAL_PLACEMENT to 4,
+        CommonScoreSource.TEAM_ROUND_WIN to 480,
+        CommonScoreSource.TEAM_ROUND_DRAW to 240,
+        CommonScoreSource.TEAM_ROUND_LOSE to 120,
     ),
     icon = Component.text("\uEA00").font(NamespacedKey("tumbling", "games/crumble")),
     scoreboard = "crumbleScoreboard"
@@ -174,27 +169,21 @@ class CrumbleController : GameBase(
     }
 
     override val scoreMessages: HashMap<ScoreSource, (score: Int) -> Component> = hashMapOf(
-        CommonScoreSource.INDIV_ROUND_WIN to { amount ->
+        CommonScoreSource.TEAM_ROUND_WIN to { amount ->
             gameMessage(
                 Component.text("Round Won! ", NamedTextColor.WHITE)
                     .append(Component.text("[+$amount]", NamedTextColor.GOLD))
             )
         },
-        CommonScoreSource.INDIV_ROUND_DRAW to { amount ->
+        CommonScoreSource.TEAM_ROUND_DRAW to { amount ->
             gameMessage(
                 Component.text("Round Drawn! ", NamedTextColor.WHITE)
                     .append(Component.text("[+$amount]", NamedTextColor.GOLD))
             )
         },
-        CommonScoreSource.INDIV_ROUND_LOSE to { amount ->
+        CommonScoreSource.TEAM_ROUND_LOSE to { amount ->
             gameMessage(
                 Component.text("Round Lost! ", NamedTextColor.WHITE)
-                    .append(Component.text("[+$amount]", NamedTextColor.GOLD))
-            )
-        },
-        CommonScoreSource.INDIVIDUAL_PLACEMENT to { amount ->
-            gameMessage(
-                Component.text("Placement Score ")
                     .append(Component.text("[+$amount]", NamedTextColor.GOLD))
             )
         }
@@ -559,8 +548,6 @@ class CrumbleController : GameBase(
 
         val teamPlacements = getTeamPlacements()
         teamPlacements.forEach {
-            val score = (teamPlacements.size - (it.second - 1)) * getScoreSource(CommonScoreSource.TEAM_PLACEMENT)
-
             teamScoresComponent = teamScoresComponent.append(
                 Component.empty()
                     .appendNewline()
@@ -568,13 +555,6 @@ class CrumbleController : GameBase(
                     .append(it.first.formattedName)
                     .append(Component.text(" - ", NamedTextColor.GRAY))
                     .append(Component.text(teamScores[it.first]!!, NamedTextColor.YELLOW))
-                    .append(Component.text(" [+${score}]", NamedTextColor.GOLD))
-            )
-
-            grantTeamScore(
-                it.first,
-                CommonScoreSource.TEAM_PLACEMENT,
-                score
             )
         }
         teamScoresComponent = teamScoresComponent.appendNewline()
@@ -587,7 +567,6 @@ class CrumbleController : GameBase(
 
         val indivPlacements = getIndividualPlacements()
         indivPlacements.forEach {
-            val placementScore = (indivPlacements.size - (it.second - 1)) * getScoreSource(CommonScoreSource.INDIVIDUAL_PLACEMENT)
             individualScoresComponent = individualScoresComponent.append(
                 Component.empty()
                     .appendNewline()
@@ -595,21 +574,11 @@ class CrumbleController : GameBase(
                     .append(Format.formatPlayerName(it.first))
                     .append(Component.text(" - ", NamedTextColor.GRAY))
                     .append(Component.text(playerScores[it.first]!!, NamedTextColor.YELLOW))
-                    .append(Component.text(" [+${placementScore}]", NamedTextColor.GOLD))
             )
         }
 
         individualScoresComponent = individualScoresComponent.appendNewline()
         Audience.audience(Bukkit.getOnlinePlayers()).sendMessage(individualScoresComponent)
-
-        indivPlacements.forEach {
-            val placementScore = (indivPlacements.size - (it.second - 1)) * getScoreSource(CommonScoreSource.INDIVIDUAL_PLACEMENT)
-            grantScore(
-                it.first,
-                CommonScoreSource.INDIVIDUAL_PLACEMENT,
-                placementScore
-            )
-        }
 
         delay(5000)
         var eventPlacementsComponent = Component.empty()
@@ -911,7 +880,6 @@ class CrumbleController : GameBase(
 
         team.getOnlinePlayers().forEach {
             it.showTitle(title)
-            grantScore(it, CommonScoreSource.INDIV_ROUND_WIN)
         }
 
         grantTeamScore(team, CommonScoreSource.TEAM_ROUND_WIN)
@@ -927,7 +895,6 @@ class CrumbleController : GameBase(
 
         team.getOnlinePlayers().forEach {
             it.showTitle(title)
-            grantScore(it, CommonScoreSource.INDIV_ROUND_LOSE)
         }
 
         grantTeamScore(team, CommonScoreSource.TEAM_ROUND_LOSE)
@@ -943,7 +910,6 @@ class CrumbleController : GameBase(
 
         team.getOnlinePlayers().forEach {
             it.showTitle(title)
-            grantScore(it, CommonScoreSource.INDIV_ROUND_DRAW)
         }
 
         grantTeamScore(team, CommonScoreSource.TEAM_ROUND_DRAW)

--- a/src/main/kotlin/xyz/devcmb/tumblers/engine/GameBase.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/engine/GameBase.kt
@@ -359,7 +359,10 @@ abstract class GameBase(
      */
     fun grantTeamScore(team: Team, source: ScoreSource, amountOverride: Int? = null) {
         val amount = amountOverride ?: getScoreSource(source)
-        teamScores.put(team, teamScores[team]!! + amount)
+
+        team.getOnlinePlayers().forEach {
+            grantScore(it, source, amountOverride?.div(4))
+        }
         DebugUtil.info("Granting $amount score to $team with source $source")
         eventController.grantTeamScore(team, amount)
     }

--- a/src/main/kotlin/xyz/devcmb/tumblers/engine/GameBase.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/engine/GameBase.kt
@@ -351,20 +351,22 @@ abstract class GameBase(
     }
 
     /**
-     * Grants score to only a team
-     *
-     * This does not affect individual placements
+     * Grants a score equally amongst a team
      * @param team The team to give score to
      * @param source The source of score
      */
+
     fun grantTeamScore(team: Team, source: ScoreSource, amountOverride: Int? = null) {
         val amount = amountOverride ?: getScoreSource(source)
+        val playerCount = team.getOnlinePlayers().size
+
+        if (amount % playerCount != 0) {
+            DebugUtil.warning("Attempted to give team ${team.name} ($playerCount players) $amount score, which cannot be divided equally, giving ${(amount / playerCount) * playerCount} score instead of $amount")
+        }
 
         team.getOnlinePlayers().forEach {
-            grantScore(it, source, amountOverride?.div(4))
+            grantScore(it, source, amount / playerCount)
         }
-        DebugUtil.info("Granting $amount score to $team with source $source")
-        eventController.grantTeamScore(team, amount)
     }
 
     /**

--- a/src/main/kotlin/xyz/devcmb/tumblers/engine/score/CommonScoreSource.kt
+++ b/src/main/kotlin/xyz/devcmb/tumblers/engine/score/CommonScoreSource.kt
@@ -3,12 +3,11 @@ package xyz.devcmb.tumblers.engine.score
 enum class CommonScoreSource(override val id: String) : ScoreSource {
     KILL("kill"),
     OUTLAST("outlast"),
+    @Deprecated("Team scores are being phased out, please only use individual scoring")
     TEAM_PLACEMENT("team_placement"),
+    @Deprecated("Individual bonuses are being removed")
     INDIVIDUAL_PLACEMENT("individual_placement"),
     TEAM_ROUND_WIN("team_round_win"),
     TEAM_ROUND_DRAW("team_round_draw"),
     TEAM_ROUND_LOSE("team_round_lose"),
-    INDIV_ROUND_WIN("indiv_round_win"),
-    INDIV_ROUND_DRAW("indiv_round_draw"),
-    INDIV_ROUND_LOSE("indiv_round_lose")
 }


### PR DESCRIPTION
- grantTeamScore now takes a score source and distributes it equally among the team
- this means that `INDIV_ROUND_WIN` and its other variants are now removed
- deprecate `TEAM_PLACEMENT` and `INDIVIDUAL_PLACEMENT` score sources, because you should not get more points for getting more points. why. why. why.
- make necessary changes to CrumbleController so that score still works as intended with the new system